### PR TITLE
Use regex to get RMSD instead of split

### DIFF
--- a/tmalign.js
+++ b/tmalign.js
@@ -93,7 +93,7 @@ function parse(output) {
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         if (line.startsWith('Aligned length=')) {
-            rmsd = parseFloat(line.split(" ")[8]);
+            rmsd = parseFloat(line.match(/RMSD=\s*(\d*\.\d*),/)[1])
         }
         if (line.startsWith("Name of Chain_1:")) {
             chain1 = line.split(" ")[3].replace(/^\s+|\s+$/g, '');


### PR DESCRIPTION
should fix incorrect values (NaN) in search with e.g. AF-X1D8M4-F1-model_v4 vs AF-A0A132Z880-F1-model_v4